### PR TITLE
If applied this will fix trailing characters error

### DIFF
--- a/colors/deep-space.vim
+++ b/colors/deep-space.vim
@@ -56,7 +56,7 @@ if g:deepspace_italics == 1
     call s:HL("Comment",                s:mid_gray,     s:none,             {'cterm': 'italic',     'gui': 'italic'})
     call s:HL("Todo",                   s:pink,         s:none,             {'cterm': 'bolditalic', 'gui': 'bolditalic'})
 else
-    call s:HL("Comment",                s:mid_gray,     s:none)             {'gui': 'italic'}
+    call s:HL("Comment",                s:mid_gray,     s:none,             {'gui': 'italic'})
     call s:HL("Todo",                   s:pink,         s:none,             {'cterm': 'bold',       'gui': 'bolditalic'})
 endif
 


### PR DESCRIPTION
There was an error introduced in commit 8d93fca that threw a trailing
characters error on line 59. This corrects the typo.
Ref: https://github.com/tyrannicaltoucan/vim-deep-space/commit/8d93fca29643f963ed93df0cf3d9b4c1cb0dd9d6#diff-21e2c4a482b08bf998eb73539b9ad248R59